### PR TITLE
Removed necessity for meetup_config.php

### DIFF
--- a/Meetup.php
+++ b/Meetup.php
@@ -1,18 +1,5 @@
 <?php
 
-// API authoriaztion type
-define( 'MEETUP_AUTH_KEY', 'key' );
-define( 'MEETUP_AUTH_OATUH2', 'oauth2' );
-
-require_once( 'meetup_config.php' );
-
-// Choose the authorization type
-define( 'MEETUP_AUTH_TYPE', $meetup_auth_type );
-
-// Meetup.com API Key
-//define( 'MEETUP_API_KEY' , '<PUT YOUR MEETUP API KEY HERE - http://www.meetup.com/meetup_api/key/>' );
-define( 'MEETUP_API_KEY', $meetup_api_key);
-
 // Meetup.com API URL
 define( 'MEETUP_API_URL', 'https://api.meetup.com' );
 
@@ -47,6 +34,7 @@ define('MEETUP_ENDPOINT_OPEN_VENUES', '/2/open_venues');
 define('MEETUP_ENDPOINT_VENUES', '/2/venues');
 
 // Setup includes - this should be an autoloader soon
+require_once('MeetupConnection.class.php');
 require_once('MeetupApiResponse.class.php');
 require_once('MeetupApiRequest.class.php');
 require_once('MeetupExceptions.class.php');

--- a/Meetup.php
+++ b/Meetup.php
@@ -2,6 +2,8 @@
 
 // Meetup.com API URL
 define( 'MEETUP_API_URL', 'https://api.meetup.com' );
+define( 'MEETUP_AUTH_URL', 'https://secure.meetup.com/oauth2/authorize' );
+define( 'MEETUP_ACCESS_TOKEN_URL', 'https://secure.meetup.com/oauth2/access' );
 
 
 // API Endpoints

--- a/MeetupApiRequest.class.php
+++ b/MeetupApiRequest.class.php
@@ -6,10 +6,14 @@
 
 class MeetupApiRequest {
 
+    private $_conn;
+
     /**
      * Default constructor
      */
-    public function __construct() {}
+    public function __construct($conn) {
+        $this->_conn = $conn; 
+    }
 
     /**
      * Performs the GET query against the specified endpoint
@@ -76,7 +80,7 @@ class MeetupApiRequest {
         foreach($Parameters AS $k => $v) {
             $params .= "&$k=$v";
         }
-        return MEETUP_API_URL . $Endpoint . "?key=" . MEETUP_API_KEY . $params;
+        return MEETUP_API_URL . $Endpoint . "?key=" . $this->_conn->auth_params['key'] . $params;
     }
 
     /**

--- a/MeetupApiRequest.class.php
+++ b/MeetupApiRequest.class.php
@@ -9,105 +9,19 @@ class MeetupApiRequest {
     private $_conn;
 
     /**
-     * Default constructor
+     * @param MeetupConnection The connection instance
      */
     public function __construct($conn) {
         $this->_conn = $conn; 
     }
 
-    /**
-     * Performs the GET query against the specified endpoint
-     *
-     * @throws MeetupBadRequestException
-     * @throws MeetupUnauthorizedRequestException
-     * @throws MeetupInternalServerErrorException
-     * @param String $Url - Endpoint with URL paramters (for now)
-     * @return MeetupApiResponse
-     */
     public function get( $Url ) {
-        // Clear error status
-        $ret = false;
-        
-        $options = array(
-            CURLOPT_RETURNTRANSFER => true,     // return web page
-            CURLOPT_HEADER         => true,    // don't return headers
-            CURLOPT_USERAGENT      => "PHP Meetup.com API Client", // who am i
-            CURLOPT_CONNECTTIMEOUT => 120,      // timeout on connect
-            CURLOPT_TIMEOUT        => 120,      // timeout on response
-            CURLOPT_HEADER => 0
-        );
-//echo $Url;
-        $ch = curl_init( $Url );
-        curl_setopt_array( $ch, $options );
-        $content = curl_exec( $ch );
-        $header  = curl_getinfo( $ch );
-        curl_close( $ch );
-        $header['content'] = $content;
-
-        $response = new MeetupApiResponse();
-        $response->setHttpCode($header['http_code']);
-        $response->setResponse($header['content']);
-        
-
-
-        if( $response->getHttpCode() == '400' ) {
-            // 400 Bad request when there was a problem with the request
-            throw new MeetupBadRequestException($Url, $response);
-        } else if ( $response->getHttpCode() == '401' ) {
-            // 401 Unauthorized when you don't provide a valid key
-            throw new MeetupUnauthorizedRequestException();
-        } else if ( $response->getHttpCode() == '500' ) {
-            // 500 Internal Server Error
-            throw new MeetupInternalServerErrorException();
-        }
-
-        return $response;
+        return $this->_conn->get( $Url );
     }
 
-    /**
-     *
-     * @throws MeetupInvalidParametersException
-     * @param <type> $Endpoint
-     * @param <type> $Parameters
-     * @param <type> $RequiredParameters - Optional - Some endpoints do not have parameters
-     * @return <type>
-     */
-    public function buildUrl( $Endpoint, $Parameters, $RequiredParameters = null ) {
-        if(is_array($RequiredParameters) && !$this->verifyParameters( $RequiredParameters, $Parameters )) {
-            throw new MeetupInvalidParametersException( $RequiredParameters );
-        }
-        $params = '';
-        foreach($Parameters AS $k => $v) {
-            $params .= "&$k=$v";
-        }
-        return MEETUP_API_URL . $Endpoint . "?key=" . $this->_conn->auth_params['key'] . $params;
+    public function buildUrl( $EndPoint, $Parameters, $RequiredParameters = null ) {
+        return $this->_conn->buildUrl( $EndPoint, $Parameters, $RequiredParameters );
     }
 
-    /**
-     * Checks the input parameters against a list of required parameters to
-     * ensure at least one of the required parameters exists.
-     *
-     * NOTE: The Meetup API contains a list of parameters that are required for
-     * each endpoint with a default condition of "any of"
-     * 
-     * @param Array $RequiredList - Names of required parameters
-     * @param Array $Parameters - List of provided paramters
-     * @return Boolean
-     */
-    public function verifyParameters($RequiredList, $Parameters) {
-        $Parameters = array_keys($Parameters);
-
-        /*
-         * Check to see if any of the required list is in the parameters array
-         * Since the Meetup API requires "any of" if a required key is found in
-         * parameters the verification will pass
-         */
-        foreach($RequiredList AS $r) {
-            if(in_array($r, $Parameters)) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 } // end class

--- a/MeetupConnection.class.php
+++ b/MeetupConnection.class.php
@@ -14,9 +14,16 @@ class MeetupConnection {
      * @param String $auth_type - The authentication type. Only 'key' is supported
      */
     public function __construct($auth_type, $params=array()) {
-	if (in_array($auth_type, $this->allowed_auth_types)) {
+        if (in_array($auth_type, $this->allowed_auth_types)) {
             $this->auth_type = $auth_type;
-            $this->auth_params = $params;
-}
-    }	
+            if ($auth_type == 'key') {
+                if (array_key_exists('key', $params))
+                    $this->auth_params = $params;
+                else
+                    throw new Exception('Invalid parameters for MeetupConnection construction');
+            }
+        } else {
+            throw new Exception('Invalid parameters for MeetupConnection construction');
+        }
+    }
 }

--- a/MeetupConnection.class.php
+++ b/MeetupConnection.class.php
@@ -4,26 +4,134 @@
  * Currently only supports api key authentication, but can be extended to
  * support oAuth.
  */
-class MeetupConnection {
-    public $allowed_auth_types = array('key');
-    public $auth_type;
-    public $auth_params;
-    /*
-     * Initializes a connection to the Meetup API
+abstract class MeetupConnection {
+	abstract protected function get( $Url );
+	abstract protected function buildUrl( $Endpoint, $Parameters, $RequiredParameters );
+    /**
+     * Checks the input parameters against a list of required parameters to
+     * ensure at least one of the required parameters exists.
+     *
+     * NOTE: The Meetup API contains a list of parameters that are required for
+     * each endpoint with a default condition of "any of"
      * 
-     * @param String $auth_type - The authentication type. Only 'key' is supported
+     * @param Array $RequiredList - Names of required parameters
+     * @param Array $Parameters - List of provided paramters
+     * @return Boolean
      */
-    public function __construct($auth_type, $params=array()) {
-        if (in_array($auth_type, $this->allowed_auth_types)) {
-            $this->auth_type = $auth_type;
-            if ($auth_type == 'key') {
-                if (array_key_exists('key', $params))
-                    $this->auth_params = $params;
-                else
-                    throw new Exception('Invalid parameters for MeetupConnection construction');
+    public function verifyParameters($RequiredList, $Parameters) {
+        $Parameters = array_keys($Parameters);
+
+        /*
+         * Check to see if any of the required list is in the parameters array
+         * Since the Meetup API requires "any of" if a required key is found in
+         * parameters the verification will pass
+         */
+        foreach($RequiredList AS $r) {
+            if(in_array($r, $Parameters)) {
+                return true;
             }
-        } else {
-            throw new Exception('Invalid parameters for MeetupConnection construction');
         }
+        return false;
+    }
+}
+
+class KeyAuthMeetupConnection extends MeetupConnection {
+	/*
+	* Initializes a connection to the Meetup API
+	* 
+	* @param String $auth_type - The authentication type. Only 'key' is supported
+	*/
+	private $_key;
+
+	public function __construct($key) {
+		$this->_key = $key;
+	}
+
+    /**
+     * Performs the GET query against the specified endpoint
+     *
+     * @throws MeetupBadRequestException
+     * @throws MeetupUnauthorizedRequestException
+     * @throws MeetupInternalServerErrorException
+     * @param String $Url - Endpoint with URL paramters (for now)
+     * @return MeetupApiResponse
+     */
+    public function get( $Url ) {
+        // Clear error status
+        $ret = false;
+        
+        $options = array(
+            CURLOPT_RETURNTRANSFER => true,     // return web page
+            CURLOPT_HEADER         => true,    // don't return headers
+            CURLOPT_USERAGENT      => "PHP Meetup.com API Client", // who am i
+            CURLOPT_CONNECTTIMEOUT => 120,      // timeout on connect
+            CURLOPT_TIMEOUT        => 120,      // timeout on response
+            CURLOPT_HEADER => 0
+        );
+//echo $Url;
+        $ch = curl_init( $Url );
+        curl_setopt_array( $ch, $options );
+        $content = curl_exec( $ch );
+        $header  = curl_getinfo( $ch );
+        curl_close( $ch );
+        $header['content'] = $content;
+
+        $response = new MeetupApiResponse();
+        $response->setHttpCode($header['http_code']);
+        $response->setResponse($header['content']);
+        
+
+
+        if( $response->getHttpCode() == '400' ) {
+            // 400 Bad request when there was a problem with the request
+            throw new MeetupBadRequestException($Url, $response);
+        } else if ( $response->getHttpCode() == '401' ) {
+            // 401 Unauthorized when you don't provide a valid key
+            throw new MeetupUnauthorizedRequestException();
+        } else if ( $response->getHttpCode() == '500' ) {
+            // 500 Internal Server Error
+            throw new MeetupInternalServerErrorException();
+        }
+
+        return $response;
+    }
+
+    /**
+     *
+     * @throws MeetupInvalidParametersException
+     * @param <type> $Endpoint
+     * @param <type> $Parameters
+     * @param <type> $RequiredParameters - Optional - Some endpoints do not have parameters
+     * @return <type>
+     */
+    public function buildUrl( $Endpoint, $Parameters, $RequiredParameters = null ) {
+        if(is_array($RequiredParameters) && !$this->verifyParameters( $RequiredParameters, $Parameters )) {
+            throw new MeetupInvalidParametersException( $RequiredParameters );
+        }
+        $params = '';
+        foreach($Parameters AS $k => $v) {
+            $params .= "&$k=$v";
+        }
+        return MEETUP_API_URL . $Endpoint . "?key=" . $this->_key . $params;
+    }
+
+}
+
+class OAuth2MeetupConnection extends MeetupConnection {
+	public function __construct($client_id, $redirect_uri) {
+		
+	}	
+	public function get($url) {
+
+	}
+    public function buildUrl( $Endpoint, $Parameters, $RequiredParameters = null ) {
+        if(is_array($RequiredParameters) && !$this->verifyParameters( $RequiredParameters, $Parameters )) {
+            throw new MeetupInvalidParametersException( $RequiredParameters );
+        }
+        $params = '';
+        foreach($Parameters AS $k => $v) {
+            $params .= "&$k=$v";
+        }
+        return MEETUP_API_URL . $Endpoint . "?key=" . $this->_conn->auth_params['key'] . $params;
     }
 }

--- a/MeetupConnection.class.php
+++ b/MeetupConnection.class.php
@@ -5,47 +5,7 @@
  * support oAuth.
  */
 abstract class MeetupConnection {
-    abstract protected function get( $Url );
     abstract protected function buildUrl( $Endpoint, $Parameters, $RequiredParameters );
-    /**
-     * Checks the input parameters against a list of required parameters to
-     * ensure at least one of the required parameters exists.
-     *
-     * NOTE: The Meetup API contains a list of parameters that are required for
-     * each endpoint with a default condition of "any of"
-     * 
-     * @param Array $RequiredList - Names of required parameters
-     * @param Array $Parameters - List of provided paramters
-     * @return Boolean
-     */
-    public function verifyParameters($RequiredList, $Parameters) {
-        $Parameters = array_keys($Parameters);
-
-        /*
-         * Check to see if any of the required list is in the parameters array
-         * Since the Meetup API requires "any of" if a required key is found in
-         * parameters the verification will pass
-         */
-        foreach($RequiredList AS $r) {
-            if(in_array($r, $Parameters)) {
-                return true;
-            }
-        }
-        return false;
-    }
-}
-
-class KeyAuthMeetupConnection extends MeetupConnection {
-    /*
-    * Initializes a connection to the Meetup API
-    * 
-    * @param String $auth_type - The authentication type. Only 'key' is supported
-    */
-    private $_key;
-
-    public function __construct($key) {
-        $this->_key = $key;
-    }
 
     /**
      * Performs the GET query against the specified endpoint
@@ -95,6 +55,45 @@ class KeyAuthMeetupConnection extends MeetupConnection {
 
         return $response;
     }
+    /**
+     * Checks the input parameters against a list of required parameters to
+     * ensure at least one of the required parameters exists.
+     *
+     * NOTE: The Meetup API contains a list of parameters that are required for
+     * each endpoint with a default condition of "any of"
+     * 
+     * @param Array $RequiredList - Names of required parameters
+     * @param Array $Parameters - List of provided paramters
+     * @return Boolean
+     */
+    public function verifyParameters($RequiredList, $Parameters) {
+        $Parameters = array_keys($Parameters);
+
+        /*
+         * Check to see if any of the required list is in the parameters array
+         * Since the Meetup API requires "any of" if a required key is found in
+         * parameters the verification will pass
+         */
+        foreach($RequiredList AS $r) {
+            if(in_array($r, $Parameters)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+class KeyAuthMeetupConnection extends MeetupConnection {
+    /*
+    * Initializes a connection to the Meetup API
+    * 
+    * @param String $auth_type - The authentication type. Only 'key' is supported
+    */
+    private $_key;
+
+    public function __construct($key) {
+        $this->_key = $key;
+    }
 
     /**
      *
@@ -118,12 +117,10 @@ class KeyAuthMeetupConnection extends MeetupConnection {
 }
 
 class OAuth2MeetupConnection extends MeetupConnection {
-    public function __construct($client_id, $redirect_uri) {
-        
+    private $_access_token;
+    public function __construct($access_token) {
+	$this->_access_token = $access_token;
     }    
-    public function get($url) {
-
-    }
     public function buildUrl( $Endpoint, $Parameters, $RequiredParameters = null ) {
         if(is_array($RequiredParameters) && !$this->verifyParameters( $RequiredParameters, $Parameters )) {
             throw new MeetupInvalidParametersException( $RequiredParameters );
@@ -132,6 +129,6 @@ class OAuth2MeetupConnection extends MeetupConnection {
         foreach($Parameters AS $k => $v) {
             $params .= "&$k=$v";
         }
-        return MEETUP_API_URL . $Endpoint . "?key=" . $this->_conn->auth_params['key'] . $params;
+        return MEETUP_API_URL . $Endpoint . "?access_token=" . $this->_access_token . $params;
     }
 }

--- a/MeetupConnection.class.php
+++ b/MeetupConnection.class.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * The collection of parameters needed to make requests against the Meetup API.
+ * Currently only supports api key authentication, but can be extended to
+ * support oAuth.
+ */
+class MeetupConnection {
+    public $allowed_auth_types = array('key');
+    public $auth_type;
+    public $auth_params;
+    /*
+     * Initializes a connection to the Meetup API
+     * 
+     * @param String $auth_type - The authentication type. Only 'key' is supported
+     */
+    public function __construct($auth_type, $params=array()) {
+	if (in_array($auth_type, $this->allowed_auth_types)) {
+            $this->auth_type = $auth_type;
+            $this->auth_params = $params;
+}
+    }	
+}

--- a/MeetupConnection.class.php
+++ b/MeetupConnection.class.php
@@ -71,8 +71,10 @@ abstract class MeetupConnection {
         $Parameters = $this->modify_params($Parameters);
         $params = '';
         foreach($Parameters AS $k => $v) {
-            $params .= "&$k=$v";
+            $params .= "$k=$v&";
         }
+        rtrim($params,'&');
+
         return MEETUP_API_URL . $Endpoint . "?" . $params;
     }
 
@@ -104,18 +106,24 @@ abstract class MeetupConnection {
     }
 }
 
-class KeyAuthMeetupConnection extends MeetupConnection {
-    /*
-    * Initializes a connection to the Meetup API
-    * 
-    * @param String $auth_type - The authentication type. Only 'key' is supported
-    */
+class MeetupKeyAuthConnection extends MeetupConnection {
     private $_key;
 
+    /*
+    * Initializes a connection to the Meetup API using API keys
+    * 
+    * @param String $key - A users's Meetup api key
+    */
     public function __construct($key) {
         $this->_key = $key;
     }
 
+    /**
+     * Adds additional query parameters for key authentication
+     * 
+     * @param Array $params - request parameters
+     * @return Array modified request parameters
+     */
     public function modify_params($params) {
         $params['key'] = $this->_key;
         return $params;
@@ -123,11 +131,24 @@ class KeyAuthMeetupConnection extends MeetupConnection {
 
 }
 
-class OAuth2MeetupConnection extends MeetupConnection {
+class MeetupOAuth2Connection extends MeetupConnection {
     private $_access_token;
+
+    /*
+    * Initializes a connection to the Meetup API using oAuth 2
+    * 
+    * @param String $access_token - A valid access token received from a Meetup access token request
+    */
     public function __construct($access_token) {
 	$this->_access_token = $access_token;
     }    
+
+    /**
+     * Adds additional query parameters for key authentication
+     * 
+     * @param Array $params - request parameters
+     * @return Array modified request parameters
+     */
     public function modify_params($params) {
         $params['access_token'] = $this->_access_token;
         return $params;

--- a/MeetupConnection.class.php
+++ b/MeetupConnection.class.php
@@ -5,8 +5,8 @@
  * support oAuth.
  */
 abstract class MeetupConnection {
-	abstract protected function get( $Url );
-	abstract protected function buildUrl( $Endpoint, $Parameters, $RequiredParameters );
+    abstract protected function get( $Url );
+    abstract protected function buildUrl( $Endpoint, $Parameters, $RequiredParameters );
     /**
      * Checks the input parameters against a list of required parameters to
      * ensure at least one of the required parameters exists.
@@ -36,16 +36,16 @@ abstract class MeetupConnection {
 }
 
 class KeyAuthMeetupConnection extends MeetupConnection {
-	/*
-	* Initializes a connection to the Meetup API
-	* 
-	* @param String $auth_type - The authentication type. Only 'key' is supported
-	*/
-	private $_key;
+    /*
+    * Initializes a connection to the Meetup API
+    * 
+    * @param String $auth_type - The authentication type. Only 'key' is supported
+    */
+    private $_key;
 
-	public function __construct($key) {
-		$this->_key = $key;
-	}
+    public function __construct($key) {
+        $this->_key = $key;
+    }
 
     /**
      * Performs the GET query against the specified endpoint
@@ -68,7 +68,7 @@ class KeyAuthMeetupConnection extends MeetupConnection {
             CURLOPT_TIMEOUT        => 120,      // timeout on response
             CURLOPT_HEADER => 0
         );
-//echo $Url;
+        //echo $Url;
         $ch = curl_init( $Url );
         curl_setopt_array( $ch, $options );
         $content = curl_exec( $ch );
@@ -118,12 +118,12 @@ class KeyAuthMeetupConnection extends MeetupConnection {
 }
 
 class OAuth2MeetupConnection extends MeetupConnection {
-	public function __construct($client_id, $redirect_uri) {
-		
-	}	
-	public function get($url) {
+    public function __construct($client_id, $redirect_uri) {
+        
+    }    
+    public function get($url) {
 
-	}
+    }
     public function buildUrl( $Endpoint, $Parameters, $RequiredParameters = null ) {
         if(is_array($RequiredParameters) && !$this->verifyParameters( $RequiredParameters, $Parameters )) {
             throw new MeetupInvalidParametersException( $RequiredParameters );

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Full documentation can be found on the Github project wiki at https://github.com
 - Include the Meetup.php file in your application
 - * I.E. In /var/www/myapp/index.php
 - * Use require_once('Meetup-API-client-for-PHP/Meetup.php');
-- Edit meetup_config.php and set your Meetup API key, available at http://www.meetup.com/meetup_api/key/
+- Establish a connection to the API with your Meetup API key, available at http://www.meetup.com/meetup_api/key/
 - * $meetup_api_key = '<YOUR MEETUP API KEY>';
+- * $connection = new MeetupConnection('key', array('key' => $api_key));
 - Begin using the new Meetup functionality in your application!
 
 # Using the pre-built endpoint classes
@@ -46,7 +47,7 @@ These classes take an associative array of parameters that correspond to the par
 
 Example: Accessing all Meetup events for user Ben Lobaugh with ID 14508967. See http://www.meetup.com/meetup_api/docs/2/events/ for additional parameters and response format
 
-$m = new MeetupEvents();
+$m = new MeetupEvents($connection);
 $events = $m->getEvents( array( 'member_id' => '14508967' ) );
 
 $events will be in the form of an associative array
@@ -61,7 +62,7 @@ The MeetupApiResponse object will contain the HTTP code and API response. To use
 
 Example: Accessing all Meetup events for user Ben Lobaugh with ID 14508967. See http://www.meetup.com/meetup_api/docs/2/events/ for additional parameters and response format
 
-$m = new MeetupApiRequest();
+$m = new MeetupApiRequest($connection);
 $events = $m->query( MEETUP_ENDPOINT_EVENTS, array( 'member_id' => '14508967' ) );
 
 $events will be a MeetupApiResponse object that can be access like an array (E.G. $events['results']) or used in a loop to view each event entry (E.G. foreach( $events AS $event ) )

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Full documentation can be found on the Github project wiki at https://github.com
 - * Use require_once('Meetup-API-client-for-PHP/Meetup.php');
 - Establish a connection to the API with your Meetup API key, available at http://www.meetup.com/meetup_api/key/
 - * $meetup_api_key = '<YOUR MEETUP API KEY>';
-- * $connection = new MeetupConnection('key', array('key' => $api_key));
+- * $connection = new MeetupKeyAuthConnection($meetup_api_key);
 - Begin using the new Meetup functionality in your application!
 
 # Using the pre-built endpoint classes

--- a/meetup_config.php
+++ b/meetup_config.php
@@ -1,6 +1,0 @@
-<?php
-
-$meetup_auth_type = MEETUP_AUTH_KEY;
-
-// http://www.meetup.com/meetup_api/key/
-$meetup_api_key = '<YOUR MEETUP API KEY>';


### PR DESCRIPTION
I've removed the meetup_config.php file in favor of the construction of MeetupConnection objects.  This means that projects that use this API wrapper can use a dynamic API key (such as in the case that the project accepts an API key from the user).
