### PR TITLE
Composer Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.idea
 tst.php
+
+vendor

--- a/Meetup.php
+++ b/Meetup.php
@@ -35,19 +35,3 @@ define('MEETUP_ENDPOINT_TOPICS', '/topics');
 define('MEETUP_ENDPOINT_OPEN_VENUES', '/2/open_venues');
 define('MEETUP_ENDPOINT_VENUES', '/2/venues');
 
-// Setup includes - this should be an autoloader soon
-require_once('MeetupConnection.class.php');
-require_once('MeetupApiResponse.class.php');
-require_once('MeetupApiRequest.class.php');
-require_once('MeetupExceptions.class.php');
-
-require_once('MeetupCheckins.class.php');
-require_once('MeetupEvents.class.php');
-require_once('MeetupFeeds.class.php');
-require_once('MeetupGroups.class.php');
-require_once('MeetupMembers.class.php');
-require_once('MeetupPhotos.class.php');
-require_once('MeetupRsvps.class.php');
-require_once('MeetupTopics.class.php');
-require_once('MeetupVenues.class.php');
-require_once("MeetupOAuth2Helper.class.php");

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "blobaugh/meetup-api-client",
+    "type": "library",
+    "description": "A PHP API wrapper for the Meetup.com API",
+    "keywords": ["meetup", "api"],
+    "authors": [
+        {
+            "name": "Ben Lobaugh",
+            "email": "ben@lobaugh.net"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/blobaugh/Meetup-API-client-for-PHP/issues"
+    },
+
+    "require": {
+
+    },
+
+    "autoload": {
+        "classmap": ["."],
+        "files": ["Meetup.php"]
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,14 @@
+{
+    "hash": "9b8cd507e214c44709c2f7c5f002a500",
+    "packages": [
+
+    ],
+    "packages-dev": null,
+    "aliases": [
+
+    ],
+    "minimum-stability": "stable",
+    "stability-flags": [
+
+    ]
+}


### PR DESCRIPTION
Added support to allow install via Composer (http://getcomposer.org).

This basically means people using it can add "blobaugh/meetup-api-client" to their composer files and it will get the files and generate a autoload file, which will also include the Meetup.php file.

This package still needs to be added to Packagist so that everyone can find it, now they must manually infor the github url.

Adding to packagist can be done easily on this url: http://packagist.org/packages/submit

One more information which may be added to the composer file is the license of the library. Let me know if you like this, i'm gonna start thinking about the namespace structure.
