### PR TITLE
Added topic to list of available required parameters

### DIFF
--- a/MeetupGroups.class.php
+++ b/MeetupGroups.class.php
@@ -19,7 +19,7 @@ class MeetupGroups extends MeetupApiRequest {
      * @return Array
      */
     public function getGroups( $Parameters ) {
-        $required_params = array( 'campaign_id', 'domain', 'group_id', 'group_urlname', 'member_id', 'organizer_id', 'sponsor_id');
+        $required_params = array( 'campaign_id', 'domain', 'group_id', 'group_urlname', 'member_id', 'organizer_id', 'sponsor_id', 'topic');
         $url = $this->buildUrl( MEETUP_ENDPOINT_GROUPS, $Parameters, $required_params );
         $response =  $this->get( $url )->getResponse();
         return $response['results'];


### PR DESCRIPTION
It is useful to search groups by topic, so I've added `topic` to the array of available required parameters. This is one of the supported parameters as defined here: http://www.meetup.com/meetup_api/docs/2/groups/.
